### PR TITLE
Improvements and fixes to components #100 and #110: revised CLABMA*.2DA handling and some others

### DIFF
--- a/SubtleD_Stat_Overhauls/components/revised_stats.tpa
+++ b/SubtleD_Stat_Overhauls/components/revised_stats.tpa
@@ -619,11 +619,17 @@ ACTION_IF (change_CHA > 0) BEGIN
 END
 //__________________________________________________________________________________
 
+//Define undefined mage clabs
+//
+ACTION_FOR_EACH kitclab IN ~CLABMA01~ ~CLABMA02~ ~CLABMA03~ ~CLABMA04~ ~CLABMA05~ ~CLABMA06~ ~CLABMA07~ ~CLABMA08~ ~CLABMA09~ BEGIN 
+	ACTION_IF !(FILE_EXISTS_IN_GAME ~%kitclab%.2DA~) THEN BEGIN
+		COPY ~%MOD_FOLDER%/data/stats/BLANKCLAB.2da~ ~override/%kitclab%.2da~ // generate undefined clab files
+	END 
+END
 
 //ADD STAT BONUS EFFECT TO EVERY CLAB_______________________________________________
-//
-// no need for clabma01 because it is in kitlist.2da
-ACTION_FOR_EACH trueclass IN ~clabba01~ ~clabdr01~ ~clabfi01~ /*~clabma01~*/ ~clabmo01~ ~clabpa01~ ~clabpr01~ ~clabrn01~ ~clabsh01~ ~clabth01~ BEGIN
+// bonuses for base classes, clabma01 included, because it might or might not be present in kitlist.2da (depending on other mods installed)
+ACTION_FOR_EACH trueclass IN ~clabba01~ ~clabdr01~ ~clabfi01~ ~clabma01~ ~clabmo01~ ~clabpa01~ ~clabpr01~ ~clabrn01~ ~clabsh01~ ~clabth01~ BEGIN
   ACTION_IF (FILE_EXISTS_IN_GAME ~%trueclass%.2da~) BEGIN
     APPEND ~%trueclass%.2da~ ~ABILITY     AP_D5_STAT1 ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****       ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        **** ~ UNLESS ~AP_D5_STAT1~
   END
@@ -633,7 +639,7 @@ COPY_EXISTING ~kitlist.2da~ ~override~
   FOR ( index = 2 ; index < rows ; index = index + 1 ) BEGIN
     READ_2DA_ENTRY %index% 5 9 modclab
     READ_2DA_ENTRY %index% 8 9 modclass
-    PATCH_IF (modclass = 1) OR (modclass = 2) OR (modclass = 3) OR (modclass = 4) OR (modclass = 5) OR (modclass = 6) OR (modclass = 11) OR (modclass = 12) OR (modclass = 19) OR (modclass = 20) OR (modclass = 21) BEGIN
+    PATCH_IF (modclass = 1 AND !(~%modclab%~ STRING_EQUAL_CASE ~CLABMA01~)) OR (modclass = 2) OR (modclass = 3) OR (modclass = 4) OR (modclass = 5) OR (modclass = 6) OR (modclass = 11) OR (modclass = 12) OR (modclass = 19) OR (modclass = 20) OR (modclass = 21) BEGIN
       INNER_ACTION BEGIN
         ACTION_IF (FILE_EXISTS_IN_GAME ~%modclab%.2da~) BEGIN
           APPEND ~%modclab%.2da~ ~ABILITY     AP_D5_STAT1 ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****       ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        **** ~ UNLESS ~AP_D5_STAT1~

--- a/SubtleD_Stat_Overhauls/components/revised_stats.tpa
+++ b/SubtleD_Stat_Overhauls/components/revised_stats.tpa
@@ -257,9 +257,6 @@ ACTION_IF (change_INT > 0) BEGIN
   ACTION_IF NOT FILE_EXISTS_IN_GAME ~qdtnb_attrbon.qd~ BEGIN
    COPY ~%MOD_FOLDER%/data/stats/d5_statx.spl~ ~override/d5int12.spl~
 	LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 parameter2 = 0 target = 1 timing = 1 STR_VAR resource = ~d5int12~ END
-	PATCH_IF NOT FILE_EXISTS_IN_GAME ~qdtnb_attrbon.qd~ BEGIN
-	  LPF ADD_SPELL_EFFECT INT_VAR opcode = 42 parameter1 = (0 - 1) parameter2 = 511 target = 1 timing = 0 duration = 7 END
-	END
    COPY ~%MOD_FOLDER%/data/stats/d5_statx.spl~ ~override/d5int13.spl~
 	LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 parameter2 = 0 target = 1 timing = 1 STR_VAR resource = ~d5int13~ END
    COPY ~%MOD_FOLDER%/data/stats/d5_statx.spl~ ~override/d5int14.spl~

--- a/SubtleD_Stat_Overhauls/components/stat_bonus_spells.tpa
+++ b/SubtleD_Stat_Overhauls/components/stat_bonus_spells.tpa
@@ -164,16 +164,17 @@ END
 //COPY ~%MOD_FOLDER%/data/ability_bonuses/d5_slot1.spl~ ~override/d5absp1.spl~
 COPY ~%MOD_FOLDER%/lib/d5_base.spl~ ~override/d5absp1.spl~
 	LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5absp1~ END
+	LPF ADD_SPELL_EFFECT INT_VAR opcode = 177 target = 1 parameter1 = 19 parameter2 = 5 timing = 9 STR_VAR resource = ~d5absps~ END
 	LPF ADD_SPELL_EFFECT INT_VAR opcode = 177 target = 1 parameter1 = 0 parameter2 = 2 timing = 9 STR_VAR resource = ~d5abspw~ END
-	LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5absp1~ END
+	//LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5abspw~ END
 //COPY ~%MOD_FOLDER%/data/ability_bonuses/d5_slot1.spl~ ~override/d5absp2.spl~
 COPY ~%MOD_FOLDER%/lib/d5_base.spl~ ~override/d5absp2.spl~
 	LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5absp2~ END
 	LPF ADD_SPELL_EFFECT INT_VAR opcode = 177 target = 1 parameter1 = 5 parameter2 = 5 timing = 9 STR_VAR resource = ~d5abspb~ END
 //COPY ~%MOD_FOLDER%/data/ability_bonuses/d5_slot1.spl~ ~override/d5absp3.spl~
-COPY ~%MOD_FOLDER%/lib/d5_base.spl~ ~override/d5absp3.spl~
-	LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5absp3~ END
-	LPF ADD_SPELL_EFFECT INT_VAR opcode = 177 target = 1 parameter1 = 19 parameter2 = 5 timing = 9 STR_VAR resource = ~d5absps~ END
+//COPY ~%MOD_FOLDER%/lib/d5_base.spl~ ~override/d5absp3.spl~
+//	LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5absp3~ END
+//	LPF ADD_SPELL_EFFECT INT_VAR opcode = 177 target = 1 parameter1 = 19 parameter2 = 5 timing = 9 STR_VAR resource = ~d5absps~ END
 
 COPY ~%MOD_FOLDER%/data/ability_bonuses/d5_slots.eff~ ~override/d5abspw.eff~
 	WRITE_ASCII 0x30 ~d5abspw~ #8
@@ -215,6 +216,32 @@ COPY ~%MOD_FOLDER%/data/ability_bonuses/d5_slots.spl~ ~override/d5abspb.spl~ 	//
 	LPF ADD_SPELL_EFFECT INT_VAR opcode = 326 parameter1 = 24 parameter2 = %chr_slots% target = 1 timing = 1 STR_VAR resource = ~d5chrbx~ END
 //	LPF ADD_SPELL_EFFECT INT_VAR opcode = 326 parameter1 = 25 parameter2 = %chr_slots% target = 1 timing = 1 STR_VAR resource = ~d5chrby~ END
 COPY ~%MOD_FOLDER%/data/ability_bonuses/d5_slots.spl~ ~override/d5absps.spl~ 	// 	spell slot modifications for sorcerers
+	LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5abspw~ END
+  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5intwm~ END
+  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5intwn~ END
+  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5intwo~ END
+  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5intwp~ END
+  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5intwq~ END
+  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5intwr~ END
+  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5intws~ END
+  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5intwt~ END
+  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5intwu~ END
+  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5intww~ END
+  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5intwx~ END
+  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5intwy~ END
+  LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5abspw~ END
+  LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5intwm~ END
+  LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5intwn~ END
+  LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5intwo~ END
+  LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5intwp~ END
+  LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5intwq~ END
+  LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5intwr~ END
+  LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5intws~ END
+  LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5intwt~ END
+  LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5intwu~ END
+  LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5intww~ END
+  LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5intwx~ END
+  LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5intwy~ END
 	LPF ADD_SPELL_EFFECT INT_VAR opcode = 326 parameter1 = 13 parameter2 = 133 target = 1 timing = 1 STR_VAR resource = ~d5chrsl~ END
 	LPF ADD_SPELL_EFFECT INT_VAR opcode = 326 parameter1 = 13 parameter2 = %chr_slots% target = 1 timing = 1 STR_VAR resource = ~d5chrsm~ END
 	LPF ADD_SPELL_EFFECT INT_VAR opcode = 326 parameter1 = 14 parameter2 = %chr_slots% target = 1 timing = 1 STR_VAR resource = ~d5chrsn~ END
@@ -406,9 +433,10 @@ COPY ~%MOD_FOLDER%/data/ability_bonuses/d5_slots.spl~ ~override/d5absps.spl~ 	//
 	LPF ADD_SPELL_EFFECT INT_VAR opcode = 191 parameter1 = 4 parameter2 = 0 target = 1 timing = 0 duration = 7 END
 
 
-// 		only sorcerer bonuses - wild mage is in kitlist so will add wizard bonuses below
+// 		sorcerer and generalist mage bonuses - wildmage might or might not be clabma01 in kitlist.2da (depending on other mods installed)
 ACTION_IF FILE_EXISTS_IN_GAME ~clabma01.2da~ BEGIN
-	APPEND ~clabma01.2da~ ~XTRA_SPL    AP_D5ABSP3  ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****       ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****  ~
+//	APPEND ~clabma01.2da~ ~XTRA_SPL    AP_D5ABSP3  ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****       ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****  ~
+	APPEND ~clabma01.2da~ ~XTRA_SPL    AP_D5ABSP1  ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****       ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****  ~
 END
 	 
 ACTION_IF FILE_EXISTS_IN_GAME ~clabba01.2da~ BEGIN
@@ -442,7 +470,7 @@ COPY_EXISTING ~kitlist.2da~ ~override~
 	READ_2DA_ENTRY %row% 5 10 modclab
 	READ_2DA_ENTRY %row% 8 10 modclass
     PATCH_IF (FILE_EXISTS_IN_GAME ~%modclab%.2da~) BEGIN
-	  PATCH_IF (%modclass% = 1) AND !(~%modname%~ STRING_MATCHES_REGEXP ~C0SA+~ = 0) AND !(~%modclab%~ STRING_EQUAL_CASE ~D5ACNST~) AND !(~%modclab%~ STRING_EQUAL_CASE ~D5_MANA~) BEGIN	// mage kits
+	  PATCH_IF (%modclass% = 1 AND !(~%modclab%~ STRING_EQUAL_CASE ~CLABMA01~)) AND !(~%modname%~ STRING_MATCHES_REGEXP ~C0SA+~ = 0) AND !(~%modclab%~ STRING_EQUAL_CASE ~D5ACNST~) AND !(~%modclab%~ STRING_EQUAL_CASE ~D5_MANA~) BEGIN	// mage kits, excluding clabma01
 	    INNER_ACTION BEGIN
 		  APPEND ~%modclab%.2da~ ~XTRA_SPL    AP_D5ABSP1  ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****       ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****  ~
 	    END
@@ -454,10 +482,10 @@ COPY_EXISTING ~kitlist.2da~ ~override~
 	  END
 	  PATCH_IF (%modclass% = 19) AND !(~%modname%~ STRING_MATCHES_REGEXP ~C0SA+~ = 0) BEGIN 	// sorcerer kits
 	    INNER_ACTION BEGIN
-		  APPEND ~%modclab%.2da~ ~XTRA_SPL    AP_D5ABSP3  ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****       ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****  ~
+		  APPEND ~%modclab%.2da~ ~XTRA_SPL    AP_D5ABSP1  ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****       ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****  ~
 	    END
 	  END
-	  PATCH_IF (%modclass% = 1) OR (%modclass% = 5) OR (%modclass% = 19) OR (%modclass% = 7) OR (%modclass% = 10) OR (%modclass% = 13) OR (%modclass% = 14) OR (%modclass% = 17) BEGIN
+	  PATCH_IF (%modclass% = 1 AND !(~%modclab%~ STRING_EQUAL_CASE ~CLABMA01~)) OR (%modclass% = 5) OR (%modclass% = 19) OR (%modclass% = 7) OR (%modclass% = 10) OR (%modclass% = 13) OR (%modclass% = 14) OR (%modclass% = 17) BEGIN
 	    PATCH_IF (~%modname%~ STRING_MATCHES_REGEXP ~C0SA+~ = 0) BEGIN	// shadow adept arcane kits
 		  INNER_ACTION BEGIN
 		    APPEND ~%modclab%.2da~ ~XTRA_SPL    AP_D5ZISLT  ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****       ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****        ****  ~

--- a/SubtleD_Stat_Overhauls/components/stat_bonus_spells.tpa
+++ b/SubtleD_Stat_Overhauls/components/stat_bonus_spells.tpa
@@ -166,15 +166,10 @@ COPY ~%MOD_FOLDER%/lib/d5_base.spl~ ~override/d5absp1.spl~
 	LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5absp1~ END
 	LPF ADD_SPELL_EFFECT INT_VAR opcode = 177 target = 1 parameter1 = 19 parameter2 = 5 timing = 9 STR_VAR resource = ~d5absps~ END
 	LPF ADD_SPELL_EFFECT INT_VAR opcode = 177 target = 1 parameter1 = 0 parameter2 = 2 timing = 9 STR_VAR resource = ~d5abspw~ END
-	//LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5abspw~ END
 //COPY ~%MOD_FOLDER%/data/ability_bonuses/d5_slot1.spl~ ~override/d5absp2.spl~
 COPY ~%MOD_FOLDER%/lib/d5_base.spl~ ~override/d5absp2.spl~
 	LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5absp2~ END
 	LPF ADD_SPELL_EFFECT INT_VAR opcode = 177 target = 1 parameter1 = 5 parameter2 = 5 timing = 9 STR_VAR resource = ~d5abspb~ END
-//COPY ~%MOD_FOLDER%/data/ability_bonuses/d5_slot1.spl~ ~override/d5absp3.spl~
-//COPY ~%MOD_FOLDER%/lib/d5_base.spl~ ~override/d5absp3.spl~
-//	LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5absp3~ END
-//	LPF ADD_SPELL_EFFECT INT_VAR opcode = 177 target = 1 parameter1 = 19 parameter2 = 5 timing = 9 STR_VAR resource = ~d5absps~ END
 
 COPY ~%MOD_FOLDER%/data/ability_bonuses/d5_slots.eff~ ~override/d5abspw.eff~
 	WRITE_ASCII 0x30 ~d5abspw~ #8
@@ -216,32 +211,8 @@ COPY ~%MOD_FOLDER%/data/ability_bonuses/d5_slots.spl~ ~override/d5abspb.spl~ 	//
 	LPF ADD_SPELL_EFFECT INT_VAR opcode = 326 parameter1 = 24 parameter2 = %chr_slots% target = 1 timing = 1 STR_VAR resource = ~d5chrbx~ END
 //	LPF ADD_SPELL_EFFECT INT_VAR opcode = 326 parameter1 = 25 parameter2 = %chr_slots% target = 1 timing = 1 STR_VAR resource = ~d5chrby~ END
 COPY ~%MOD_FOLDER%/data/ability_bonuses/d5_slots.spl~ ~override/d5absps.spl~ 	// 	spell slot modifications for sorcerers
-	LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5abspw~ END
-  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5intwm~ END
-  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5intwn~ END
-  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5intwo~ END
-  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5intwp~ END
-  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5intwq~ END
-  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5intwr~ END
-  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5intws~ END
-  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5intwt~ END
-  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5intwu~ END
-  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5intww~ END
-  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5intwx~ END
-  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5intwy~ END
   LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5abspw~ END
-  LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5intwm~ END
-  LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5intwn~ END
-  LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5intwo~ END
-  LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5intwp~ END
-  LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5intwq~ END
-  LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5intwr~ END
-  LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5intws~ END
-  LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5intwt~ END
-  LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5intwu~ END
-  LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5intww~ END
-  LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5intwx~ END
-  LPF ADD_SPELL_EFFECT INT_VAR opcode = 321 target = 1 timing = 9 STR_VAR resource = ~d5intwy~ END
+  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 318 target = 1 parameter1 = 19 parameter2 = 105 timing = 0 duration = 1 STR_VAR resource = ~d5abspw~ END
 	LPF ADD_SPELL_EFFECT INT_VAR opcode = 326 parameter1 = 13 parameter2 = 133 target = 1 timing = 1 STR_VAR resource = ~d5chrsl~ END
 	LPF ADD_SPELL_EFFECT INT_VAR opcode = 326 parameter1 = 13 parameter2 = %chr_slots% target = 1 timing = 1 STR_VAR resource = ~d5chrsm~ END
 	LPF ADD_SPELL_EFFECT INT_VAR opcode = 326 parameter1 = 14 parameter2 = %chr_slots% target = 1 timing = 1 STR_VAR resource = ~d5chrsn~ END


### PR DESCRIPTION
1. Component `#100 "revised stats"` had a weird effect for `INT=12`: a `-1 wizard spell slot for every spell level`. I think this was a bug, so I removed it.

2. Both components `#100 "revised stats"` and `#110 "bonus spells"` had some unsafe assumptions about `CLABMA01.2DA`. In a base game without any other mods this worked fine, because weirdly enough, `CLABMA01` represents generalist mages, base sorcerers and wildmages (including a entry in `KITLIST.2DA`). The problem is that some components (namely `SCS)` fix this inconsistency by assigning wildmages their own `CLABMA10` and thus removing `CLABMA01` from `KITLIST.2DA`.. and breaking compatibility with your implementation. I fixed it by treating `CLABMA01` just like other "base classes" and excluding it from kitlist loop. This way it works just fine with or without `SCS`.

3. Component `#110 "bonus spells"`: Your implementation of extra spells for wizard and sorcerers added two `XTRA_SPL` rows to `CLABMA01.2DA`:
```
XTRA_SPL    AP_D5ABSP1
XTRA_SPL    AP_D5ABSP3
```
which I think is invalid. It works, but just for safety I changed the implementation to only add a single AP_D5ABSP1 that handles bonus spells for both mages and sorcerers. 